### PR TITLE
Fix toolbars

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -88,6 +88,8 @@
 //= require qs
 //= require miq_timeline
 // Bower packages
+//= require angular-ui-sortable
+//= require angular-dragdrop
 //= require manageiq-ui-components/dist/js/ui-components
 //= require rx-angular/dist/rx.angular
 //= require patternfly-timeline/dist/timeline

--- a/app/controllers/mixins/generic_show_mixin.rb
+++ b/app/controllers/mixins/generic_show_mixin.rb
@@ -19,12 +19,11 @@ module Mixins
 
     def show_main
       get_tagdata(@record)
-      drop_breadcrumb({:name => ui_lookup(:tables => self.class.table_name),
-                       :url  => "/#{self.class.table_name}/show_list?page=#{@current_page}&refresh=y"},
+      drop_breadcrumb({:name => ui_lookup(:models => self.class.model.to_s),
+                       :url  => "/#{controller_name}/show_list?page=#{@current_page}&refresh=y"},
                       true)
 
-      show_url = restful? ? "/#{self.class.table_name}/" :
-                            "/#{self.class.table_name}/show/"
+      show_url = restful? ? "/#{controller_name}/" : "/#{controller_name}/show/"
 
       drop_breadcrumb(:name =>  _("%{name} (Summary)") % {:name => @record.name},
                       :url  => "#{show_url}#{@record.id}")

--- a/app/helpers/application_helper/button/miq_alert_delete.rb
+++ b/app/helpers/application_helper/button/miq_alert_delete.rb
@@ -1,5 +1,5 @@
 class ApplicationHelper::Button::MiqAlertDelete < ApplicationHelper::Button::Basic
-  needs @record
+  needs :@record
 
   def disabled?
     @error_message = N_("Alerts referenced by Actions can not be deleted") unless @record.owning_miq_actions.empty?

--- a/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
+++ b/spec/shared/controllers/shared_examples_for_ems_network_controller.rb
@@ -36,7 +36,7 @@ shared_examples :shared_examples_for_ems_network_controller do |providers|
           get :show, :params => {:id => @ems.id}
           expect(response.status).to eq(200)
           expect(response.body).to_not be_empty
-          expect(assigns(:breadcrumbs)).to eq([{:name => "Network Providers",
+          expect(assigns(:breadcrumbs)).to eq([{:name => "Network Managers",
                                                 :url  => "/ems_network/show_list?page=&refresh=y"},
                                                {:name => "Cloud Manager Network Manager (Summary)",
                                                 :url  => "/ems_network/#{@ems.id}"}])


### PR DESCRIPTION
Previous commits removed tool bars from this fork of ManageIQ.   Adding bower dependencies back in to restore this functionality.