### PR TITLE
Restores the host relationship link in the UI

### DIFF
--- a/app/helpers/host_helper/textual_summary.rb
+++ b/app/helpers/host_helper/textual_summary.rb
@@ -41,7 +41,7 @@ module HostHelper::TextualSummary
     TextualTags.new(_("Smart Management"), %i(tags))
   end
   
-  def textual_physical_server
+  def textual_physical_servers
     {:label =>  _("Physical Server"), :value  =>  @record.physical_server.name, :icon =>  "pficon pficon-server", :link => url_for(:controller  =>  'physical_server',  :action =>  'show', :id =>  @record.physical_server.id) }
   end
 


### PR DESCRIPTION
Clicking on the host on the Physical Server details page should take the user to
a page with details for the corresponding host instance.

Changing host_helper/textual_summary: textual_physical_server  to text_physical_servers