### PR TITLE
BUGFIX physical provider to physical servers relationship

### DIFF
--- a/app/views/layouts/listnav/_ems_physical_infra.html.haml
+++ b/app/views/layouts/listnav/_ems_physical_infra.html.haml
@@ -18,6 +18,6 @@
         = li_link(:if => !(@record.number_of(:physical_servers) == 0),
           :text       => _("Physical Servers"),
           :record     => @record,
-          :display    => 'physical_server',
+          :display    => 'physical_servers',
           :title      => _("Physical Servers"))
       


### PR DESCRIPTION
Fix the sidebar shortcut to physical server relationship. Now the error when the provider to physical server relationship is clicked does not occurs anymore.